### PR TITLE
public normalize method and possibility to not remove extremly unlikely candidates

### DIFF
--- a/Dym/Trigrams/TrigramWord.cs
+++ b/Dym/Trigrams/TrigramWord.cs
@@ -228,6 +228,10 @@ namespace Clockwerk.Dym.Trigrams
 		/// 
 		/// This works well for Latin-based inputs, but it basically destroys the input
 		/// for any non-Latin scripts (CJK ideographics, Cyrillic, Arabic, Hebrew, etc.).
+		///
+		/// <b>Warning:</b> This method is intended to be <i>internal</i>. Its behavior <i>may</i> change in a future
+		/// version. Anything that relies on it <i>must not</i> make assumptions about what the method does or how it
+		/// does it. For more information take a look at the pull request https://github.com/seanofw/dym/pull/1.
 		/// </summary>
 		/// <param name="text">The text to "normalize."</param>
 		/// <returns>The "normalized" input string.</returns>

--- a/Dym/Trigrams/TrigramWord.cs
+++ b/Dym/Trigrams/TrigramWord.cs
@@ -231,7 +231,7 @@ namespace Clockwerk.Dym.Trigrams
 		/// </summary>
 		/// <param name="text">The text to "normalize."</param>
 		/// <returns>The "normalized" input string.</returns>
-		private static string Normalize(string text)
+		public static string Normalize(string text)
 		{
 			if (!IsAscii(text))
 				text = text.Normalize(System.Text.NormalizationForm.FormD);

--- a/Dym/Trigrams/TrigramWordDictionary.cs
+++ b/Dym/Trigrams/TrigramWordDictionary.cs
@@ -393,13 +393,15 @@ namespace Clockwerk.Dym.Trigrams
 				int gram = pattern.Trigrams[i];
 				if (_gramLookup.TryGetValue(gram, out List<TrigramWord>? gramMatches))
 				{
-					if(!removeExtremelyUnlikely) {
+					if(!removeExtremelyUnlikely)
+					{
 						foreach (TrigramWord word in gramMatches)
 						{
 							candidates.Add(word);
 						}
 					}
-					else {
+					else
+					{
 						foreach (TrigramWord word in gramMatches)
 						{
 							if (IsCandidateExtremelyUnlikely(pattern, word))

--- a/Dym/Trigrams/TrigramWordDictionary.cs
+++ b/Dym/Trigrams/TrigramWordDictionary.cs
@@ -254,10 +254,11 @@ namespace Clockwerk.Dym.Trigrams
 		/// <param name="maximumWords">The maximum number of answers to return.</param>
 		/// <param name="minimumSimilarity">The minimum allowed similarity of each matching word.</param>
 		/// <param name="includeTags">Whether to include tag data for each matching word.</param>
+		/// <param name="removeExtremelyUnlikely">Whether words with substantially more or fewer trigrams should be removed.</param>
 		/// <returns>The list of matching words in the dictionary, if any.</returns>
 		public List<TrigramMatch> Match(string pattern,
-			int maximumWords = 100, double minimumSimilarity = 0.5, bool includeTags = true)
-			=> Match(new TrigramWord(pattern), maximumWords, minimumSimilarity, includeTags);
+			int maximumWords = 100, double minimumSimilarity = 0.5, bool includeTags = true, bool removeExtremelyUnlikely = true)
+			=> Match(new TrigramWord(pattern), maximumWords, minimumSimilarity, includeTags, removeExtremelyUnlikely);
 
 		/// <summary>
 		/// Match the given "pattern" word against the dictionary, trying to find words in
@@ -267,11 +268,12 @@ namespace Clockwerk.Dym.Trigrams
 		/// <param name="maximumWords">The maximum number of answers to return.</param>
 		/// <param name="minimumSimilarity">The minimum allowed similarity of each matching word.</param>
 		/// <param name="includeTags">Whether to include tag data for each matching word.</param>
+		/// <param name="removeExtremelyUnlikely">Whether words with substantially more or fewer trigrams should be removed.</param>
 		/// <returns>The list of matching words in the dictionary, if any.</returns>
 		public List<TrigramMatch> Match(TrigramWord pattern,
-			int maximumWords = 100, double minimumSimilarity = 0.5, bool includeTags = true)
+			int maximumWords = 100, double minimumSimilarity = 0.5, bool includeTags = true, bool removeExtremelyUnlikely = true)
 		{
-			HashSet<TrigramWord> candidates = FindGoodCandidates(pattern);
+			HashSet<TrigramWord> candidates = FindGoodCandidates(pattern, removeExtremelyUnlikely);
 
 			if (candidates.Count < maximumWords * 2)
 				AddMediocreCandidates(pattern, candidates);
@@ -378,8 +380,9 @@ namespace Clockwerk.Dym.Trigrams
 		/// "hel", "ell", or "llo", which represents a "good" initial set of candidates to try.
 		/// </summary>
 		/// <param name="pattern">The pattern to search for.</param>
+		/// <param name="removeExtremelyUnlikely">Whether words with substantially more or fewer trigrams should be removed.</param>
 		/// <returns>A reasonable initial set of candidate matches.</returns>
-		private HashSet<TrigramWord> FindGoodCandidates(TrigramWord pattern)
+		private HashSet<TrigramWord> FindGoodCandidates(TrigramWord pattern, bool removeExtremelyUnlikely = true)
 		{
 			// Start with a large HashSet, since we often end up with a lot of data.
 			// This will reduce resizes and improve performance, at the cost of some memory (temporarily).
@@ -392,7 +395,7 @@ namespace Clockwerk.Dym.Trigrams
 				{
 					foreach (TrigramWord word in gramMatches)
 					{
-						if (IsCandidateExtremelyUnlikely(pattern, word))
+						if (removeExtremelyUnlikely && IsCandidateExtremelyUnlikely(pattern, word))
 							continue;
 						candidates.Add(word);
 					}

--- a/Dym/Trigrams/TrigramWordDictionary.cs
+++ b/Dym/Trigrams/TrigramWordDictionary.cs
@@ -393,11 +393,19 @@ namespace Clockwerk.Dym.Trigrams
 				int gram = pattern.Trigrams[i];
 				if (_gramLookup.TryGetValue(gram, out List<TrigramWord>? gramMatches))
 				{
-					foreach (TrigramWord word in gramMatches)
-					{
-						if (removeExtremelyUnlikely && IsCandidateExtremelyUnlikely(pattern, word))
-							continue;
-						candidates.Add(word);
+					if(!removeExtremelyUnlikely) {
+						foreach (TrigramWord word in gramMatches)
+						{
+							candidates.Add(word);
+						}
+					}
+					else {
+						foreach (TrigramWord word in gramMatches)
+						{
+							if (IsCandidateExtremelyUnlikely(pattern, word))
+								continue;
+							candidates.Add(word);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
We are using this library for a search and made some (small) changes to it that we want to contribute.

There are two changes:
1. The normalize method for TrigramWords is made public
2. I've added a parameter to disable the cutoff of words with different length

The first change makes it possible to use the normalize method outside of the library. We need this to make sure no illegal or empty words are added to the dictionary and to sanitize the search.

The second change makes it possible to find words with different length for example: "Algo" and "Algorithmen". This enables a search feature instead of "did you mean".

The changes won't break the default behavior of the library, but add new features. So it would require a minor version increase from your side. Maybe the Readme needs to be updated, but I'm not sure on this.